### PR TITLE
Enhance board_help subcommand

### DIFF
--- a/cli/parser.go
+++ b/cli/parser.go
@@ -1,6 +1,8 @@
 package cli
 
-import "github.com/hirakiuc/alfred-jira-workflow/subcommand"
+import (
+	"github.com/hirakiuc/alfred-jira-workflow/subcommand"
+)
 
 const (
 	issueToken    = "issue"
@@ -65,7 +67,6 @@ func (p *Parser) parseBoardSubCommannd() subcommand.SubCommand {
 	}
 
 	// 'board', token, ...
-	token := p.tokenizer.NextToken()
-	parser := NewBoardCommandParser(p.tokenizer, token)
+	parser := NewBoardCommandParser(p.tokenizer)
 	return parser.Parse()
 }

--- a/subcommand/board_help.go
+++ b/subcommand/board_help.go
@@ -3,26 +3,106 @@ package subcommand
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/andygrunwald/go-jira"
 	aw "github.com/deanishe/awgo"
+	"github.com/hirakiuc/alfred-jira-workflow/api"
+	"github.com/hirakiuc/alfred-jira-workflow/cache"
+	"github.com/hirakiuc/alfred-jira-workflow/decorator"
 )
 
 // BoardHelpCommand describe a command to show the menus on board subcommands.
 type BoardHelpCommand struct {
-	BoardName string
 	BaseCommand
 }
 
-func NewBoardHelpCommand(name string, args []string) BoardHelpCommand {
+func NewBoardHelpCommand(args []string) BoardHelpCommand {
 	return BoardHelpCommand{
-		BoardName: name,
 		BaseCommand: BaseCommand{
 			Args: args,
 		},
 	}
 }
 
-func (cmd BoardHelpCommand) Run(_ctx context.Context, wf *aw.Workflow) {
+func (cmd BoardHelpCommand) fetchBoards(_ context.Context, wf *aw.Workflow) ([]jira.Board, error) {
+	store := cache.NewBoardsCache(wf)
+
+	boards, err := store.GetCache()
+	if err != nil {
+		return []jira.Board{}, err
+	}
+	if len(boards) != 0 {
+		return boards, nil
+	}
+
+	client, err := api.NewClient()
+	if err != nil {
+		return []jira.Board{}, err
+	}
+
+	boards, err = client.GetAllBoards("", "")
+	if err != nil {
+		return []jira.Board{}, err
+	}
+
+	if len(boards) == 0 {
+		return []jira.Board{}, nil
+	}
+
+	return store.Store(boards)
+}
+
+func (cmd BoardHelpCommand) fetchBoardByID(_ context.Context, _ *aw.Workflow, boardID int) (
+	*jira.Board, error) {
+	// TBD: refactoring
+	client, err := api.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	board, err := client.GetBoardByID(boardID)
+	if err != nil {
+		return nil, err
+	}
+
+	return board, nil
+}
+
+func (cmd BoardHelpCommand) showBoardLists(ctx context.Context, wf *aw.Workflow) {
+	boards, err := cmd.fetchBoards(ctx, wf)
+	if err != nil {
+		wf.FatalError(err)
+		return
+	}
+
+	d, err := decorator.NewBoardDecorator(wf)
+	if err != nil {
+		wf.FatalError(err)
+		return
+	}
+
+	for _, board := range boards {
+		v := board
+		d.SetTarget(&v)
+
+		wf.NewItem(d.Title()).
+			Subtitle(d.Subtitle()).
+			Autocomplete(fmt.Sprintf("board %s ", v.Name)).
+			Arg(v.Self).
+			Valid(true)
+	}
+
+	if cmd.HasQuery() {
+		wf.Filter(cmd.Query())
+	}
+
+	// Show a warning in Alfred if there are no items.
+	wf.WarnEmpty("No boards found.", "")
+}
+
+func (cmd BoardHelpCommand) showHelpMenus(_ context.Context, wf *aw.Workflow, board *jira.Board) {
 	subcommands := []struct {
 		name string
 		desc string
@@ -44,14 +124,50 @@ func (cmd BoardHelpCommand) Run(_ctx context.Context, wf *aw.Workflow) {
 	for _, c := range subcommands {
 		wf.NewItem(c.name).
 			Subtitle(c.desc).
-			Autocomplete(fmt.Sprintf("board %s %s ", cmd.BoardName, c.name)).
+			Autocomplete(fmt.Sprintf("board %s %s ", board.Name, c.name)).
 			Valid(false)
 	}
 
-	if cmd.HasQuery() {
-		wf.Filter(cmd.Query())
+	// Args: [BoardID, ...]
+	if len(cmd.Args) > 1 {
+		args := cmd.Args[1:]
+		wf.Filter(strings.Join(args, " "))
 	}
 
 	// Show a warning in Alfred if there are no items
 	wf.WarnEmpty("No items found.", "")
+}
+
+func (cmd BoardHelpCommand) Run(ctx context.Context, wf *aw.Workflow) {
+	// boards {boardID}, [arg, ...]
+	// If boardID is the numeric string & such board found, show help
+	if len(cmd.Args) == 0 {
+		// => show boards if no arguments are gives
+		cmd.showBoardLists(ctx, wf)
+		return
+	}
+
+	boardID, err := strconv.Atoi(cmd.Args[0])
+	if err != nil {
+		// looks like filter string
+		// => show boards list and filter by that string
+		cmd.showBoardLists(ctx, wf)
+		return
+	}
+
+	board, err := cmd.fetchBoardByID(ctx, wf, boardID)
+	if err != nil {
+		wf.FatalError(err)
+		return
+	}
+	if board == nil {
+		// no such board found
+		// => show boards list and filter by that string
+		cmd.showBoardLists(ctx, wf)
+		return
+	}
+
+	// Found that board
+	// => show menus for the board
+	cmd.showHelpMenus(ctx, wf, board)
 }


### PR DESCRIPTION
## Expected behaviors

1. `./jira board` will show the all scrum boards.
2. `./jira board non_numeric_string_word` will show the scrum boards which filtered by the word.
3. `./jira board numeric_string` 
   - if the numeric_string is the board ID, then will show menus for the board. (sprint,issues,backlog)
   - if the numeric_string is not any board ID, then will show the boards which filtered by the word.
